### PR TITLE
Update Remove-MimecastGroupMember.ps1

### DIFF
--- a/MimecastPS/Public/Remove-MimecastGroupMember.ps1
+++ b/MimecastPS/Public/Remove-MimecastGroupMember.ps1
@@ -35,7 +35,7 @@ function Remove-MimecastGroupMember {
     $jsonBody = "{
         ""data"": [
             {
-                ""id"": ""$ID"",
+                ""id"": ""$ID""
             }
         ]
     }"


### PR DESCRIPTION
Removed a comma from the jsonBody on the end of the "id" line. This caused an "Invalid JSON primitive" error.